### PR TITLE
Import jpackage incubator module - WAIT FOR JAVA15

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,8 +53,8 @@ tasks {
         dependsOn("build")
 
         doLast {
-            if (JavaVersion.current() < JavaVersion.VERSION_14) {
-                throw GradleException("Require Java 14+ to run 'jpackage' (currently ${JavaVersion.current()})")
+            if (JavaVersion.current() < JavaVersion.VERSION_15) {
+                throw GradleException("Require Java 15+ to run 'jpackage' (currently ${JavaVersion.current()})")
             }
             val projectVersion = project.version.toString()
             JPackage.buildInstaller(

--- a/buildSrc/src/main/kotlin/JPackage.kt
+++ b/buildSrc/src/main/kotlin/JPackage.kt
@@ -52,13 +52,19 @@ object JPackage {
             args.toTypedArray()
         }
 
-        return execJpackageViaRuntime(arguments)
+        return execJpackageViaToolProvider(arguments)
     }
 
     /**
      * Unfortunately this approach doesn't work until jpackage leaves the incubator status
      * More background here: https://stackoverflow.com/a/61310708/4515050
-     * TODO use this method, when jpackage leaves incubator
+     * outdated: to do: use this method, when jpackage leaves incubator
+     *
+     * After adding the jpackage incubator module via gradle.properties (using org.gradle.jvmargs),
+     * the jpackage tool is found but it throws an exception in Ubuntu stating:
+     * java.io.IOException: Command [fakeroot, dpkg-deb, ... exited with 2 code
+     * I found a bug ticket that claimed this would be fixed in OpenJDK 15
+     * TODO wait for Java 15
      */
     private fun execJpackageViaToolProvider(arguments: Array<String>): Int {
         val jpackageTool: ToolProvider = ToolProvider.findFirst("jpackage").orElseThrow {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# The jpackage tool is still in incubator status, so I have to import it's incubator module.
+# More info in buildSrc/JPackage.kt
+org.gradle.jvmargs=--add-modules=jdk.incubator.jpackage


### PR DESCRIPTION
In order to use jpackage not via the Gradle exec task but via the java ToolProvider, it's necessary to add the jpackage's incubator module to the classpath (as long as jpackage is still in incubator). Due to a bug in the the OpenJDK 14 implementation, this approach still seems to require OpenJDK 15.